### PR TITLE
Do away with 32 bit divisions for bend calculations to save execution time

### DIFF
--- a/common/synth.c
+++ b/common/synth.c
@@ -321,22 +321,21 @@ void computeBenderCVs(void)
 		{
 			bend=tuner_computeCVFromNote(currentPreset.steppedParameters[spBenderSemitones]*2,0,cv)-tuner_computeCVFromNote(0,0,cv);
 			bend*=synth.benderAmount;
-			bend/=UINT16_MAX;
-			synth.benderCVs[cv]=bend;
+			synth.benderCVs[cv]=bend>>16; // /65536
 		}
 		break;
 	case modVCF:
 		bend=currentPreset.steppedParameters[spBenderSemitones];
 		bend*=synth.benderAmount;
-		bend/=12;
+		bend*=FULL_RANGE/12; // Fixed point /12 ...
 		for(cv=pcFil1;cv<=pcFil6;++cv)
-			synth.benderCVs[cv]=bend;
+			synth.benderCVs[cv]=bend>>16; // ... after >>16
 		break;
 	case modVCA:
 		bend=currentPreset.steppedParameters[spBenderSemitones];
 		bend*=synth.benderAmount;
-		bend/=12;
-		synth.benderVolumeCV=bend;
+		bend*=FULL_RANGE/12; // Fixed point /12...
+		synth.benderVolumeCV=bend>>16; // ... after >>16
 		break;
 	default:
 		;


### PR DESCRIPTION
Really minor thing this time in the wake of pull request #44: replace three instances of int32_t divide operations with multiply and shift.