### PR TITLE
Arpsyncseq release

### DIFF
--- a/common/arp.c
+++ b/common/arp.c
@@ -103,7 +103,8 @@ FORCEINLINE void arp_setTranspose(int8_t transpose)
 FORCEINLINE void arp_resetCounter(void)
 {
 	arp.noteIndex=-1; // reinit
-	clock_reset(); // start on a note
+	if (seq_getMode(0)!=smPlaying && seq_getMode(1)!=smPlaying)
+		clock_reset(); // start on a note
 }
 
 FORCEINLINE arpMode_t arp_getMode(void)

--- a/common/arp.c
+++ b/common/arp.c
@@ -8,6 +8,8 @@
 #include "assigner.h"
 #include "storage.h"
 #include "midi.h"
+#include "clock.h"
+#include "seq.h"
 
 #define ARP_NOTE_MEMORY 128 // must stay>=128 for up/down mode
 
@@ -22,7 +24,6 @@ static struct
 	uint8_t previousNote;
 	int8_t transpose,previousTranspose;
 
-	uint16_t counter,speed;
 	int8_t hold;
 	arpMode_t mode;
 } arp;
@@ -94,16 +95,6 @@ inline void arp_setMode(arpMode_t mode, int8_t hold)
 	arp.hold=hold;
 }
 
-inline void arp_setSpeed(uint16_t speed)
-{
-	if(speed<1024)
-		arp.speed=UINT16_MAX;
-	else if(settings.syncMode==smInternal)
-		arp.speed=exponentialCourse(speed,22000.0f,500.0f);
-	else
-		arp.speed=extClockDividers[((uint32_t)speed*(sizeof(extClockDividers)/sizeof(uint16_t)))>>16];
-}
-
 FORCEINLINE void arp_setTranspose(int8_t transpose)
 {
 	arp.transpose=transpose;
@@ -112,7 +103,7 @@ FORCEINLINE void arp_setTranspose(int8_t transpose)
 FORCEINLINE void arp_resetCounter(void)
 {
 	arp.noteIndex=-1; // reinit
-	arp.counter=INT16_MAX; // start on a note
+	clock_reset(); // start on a note
 }
 
 FORCEINLINE arpMode_t arp_getMode(void)
@@ -139,8 +130,9 @@ void arp_assignNote(uint8_t note, int8_t on)
 	{
 		// if this is the first note, make sure the arp will start on it as as soon as we update
 		
-		if(isEmpty() && settings.syncMode==smInternal)
-			arp.counter=INT16_MAX; // not UINT16_MAX, to avoid overflow
+		if(isEmpty() && settings.syncMode==smInternal &&
+		   seq_getMode(0)!=smPlaying && seq_getMode(1)!=smPlaying)
+			clock_reset();
 
 		// assign note			
 		
@@ -215,18 +207,6 @@ void arp_update(void)
 	
 	if(arp.mode==amOff)
 		return;
-	
-	// speed management
-	
-	if(arp.speed==UINT16_MAX)
-		return;
-
-	++arp.counter;
-	
-	if(arp.counter<arp.speed)
-		return;
-	
-	arp.counter=0;
 	
 	// nothing to play ?
 	

--- a/common/arp.c
+++ b/common/arp.c
@@ -84,8 +84,8 @@ inline void arp_setMode(arpMode_t mode, int8_t hold)
 	{
 		killAllNotes();
 		
-		if(settings.syncMode!=smInternal)
-			arp_resetCounter();
+		if (mode!=amOff)
+			arp_resetCounter(settings.syncMode==smInternal);
 	}
 	
 	if(!hold && arp.hold)
@@ -100,11 +100,11 @@ FORCEINLINE void arp_setTranspose(int8_t transpose)
 	arp.transpose=transpose;
 }
 
-FORCEINLINE void arp_resetCounter(void)
+FORCEINLINE void arp_resetCounter(int8_t beatReset)
 {
 	arp.noteIndex=-1; // reinit
-	if (seq_getMode(0)!=smPlaying && seq_getMode(1)!=smPlaying)
-		clock_reset(); // start on a note
+	if (beatReset&&seq_getMode(0)!=smPlaying&&seq_getMode(1)!=smPlaying)
+		clock_reset(); // start immediately
 }
 
 FORCEINLINE arpMode_t arp_getMode(void)
@@ -131,9 +131,8 @@ void arp_assignNote(uint8_t note, int8_t on)
 	{
 		// if this is the first note, make sure the arp will start on it as as soon as we update
 		
-		if(isEmpty() && settings.syncMode==smInternal &&
-		   seq_getMode(0)!=smPlaying && seq_getMode(1)!=smPlaying)
-			clock_reset();
+		if(isEmpty())
+			arp_resetCounter(settings.syncMode==smInternal);
 
 		// assign note			
 		

--- a/common/arp.h
+++ b/common/arp.h
@@ -17,7 +17,7 @@ void arp_setSpeed(uint16_t speed);
 void arp_setTranspose(int8_t transpose);
 arpMode_t arp_getMode(void);
 int8_t arp_getHold(void);
-void arp_resetCounter(void);
+void arp_resetCounter(int8_t beatReset);
 
 void arp_assignNote(uint8_t note, int8_t on);
 

--- a/common/clock.c
+++ b/common/clock.c
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////////////////////////
+// Common clock for sequencer and arpeggiator
+////////////////////////////////////////////////////////////////////////////////
+
+#include "clock.h"
+
+#include "storage.h"
+
+struct
+{
+	uint16_t counter,speed;
+} clock;
+
+inline void clock_setSpeed(uint16_t speed)
+{
+	if(speed<1024)
+		clock.speed=UINT16_MAX;
+	else if(settings.syncMode==smInternal)
+		clock.speed=exponentialCourse(speed,22000.0f,500.0f);
+	else
+		clock.speed=extClockDividers[((uint32_t)speed*(sizeof(extClockDividers)/sizeof(uint16_t)))>>16];
+}
+
+inline uint16_t clock_getSpeed(void)
+{
+	return clock.speed;
+}
+
+inline uint16_t clock_getCounter(void)
+{
+	return clock.counter;
+}
+
+inline void clock_reset(void)
+{
+	clock.counter = INT16_MAX; // not UINT16_MAX, to avoid overflow
+
+}
+
+inline int8_t clock_update(void)
+{
+	// speed management
+
+	if(clock.speed==UINT16_MAX)
+		return 0;
+
+	++clock.counter;
+
+	if(clock.counter<clock.speed)
+		return 0;
+
+	clock.counter=0;
+
+	return 1;
+}

--- a/common/clock.h
+++ b/common/clock.h
@@ -1,0 +1,12 @@
+#ifndef CLOCK_H
+#define CLOCK_H
+
+#include <stdint.h>
+
+void clock_setSpeed(uint16_t speed);
+uint16_t clock_getSpeed(void);
+uint16_t clock_getCounter(void);
+void clock_reset(void);
+int8_t clock_update(void);
+
+#endif /* CLOCK_H */

--- a/common/seq.c
+++ b/common/seq.c
@@ -12,74 +12,89 @@
 static struct
 {
 	seqMode_t mode[SEQ_TRACK_COUNT];
-	uint8_t notes[SEQ_TRACK_COUNT][SEQ_NOTE_MEMORY];
-	uint8_t noteCount[SEQ_TRACK_COUNT];
-	int16_t noteIndex[SEQ_TRACK_COUNT];
+	uint8_t events[SEQ_TRACK_COUNT][SEQ_NOTE_MEMORY];
+	uint8_t eventCount[SEQ_TRACK_COUNT];
+	int16_t eventIndex[SEQ_TRACK_COUNT];
+	int16_t prevEventIndex[SEQ_TRACK_COUNT];
+	uint8_t stepCount[SEQ_TRACK_COUNT];
 
 	int8_t transpose,previousTranspose[SEQ_TRACK_COUNT];
 	uint16_t counter,speed;
+
+	uint8_t addTies;
+	uint8_t noteOns; /* how many keys are down */
 } seq;
 
 
-static void finishPreviousNote(int8_t track, int8_t offset)
+static void finishPreviousNotes(int8_t track)
 {	
-	uint8_t n;
-	int16_t ni;
-	
-	if(!seq.noteCount[track])
+	uint8_t s,n;
+
+	if(!seq.eventCount[track]||seq.prevEventIndex[track]<0)
 		return;
-	
-	// find prev note, acounting for ties
-	
-	ni=seq.noteIndex[track]+1+offset;
-	do
-	{
-		ni=(ni+seq.noteCount[track]-1)%seq.noteCount[track];
-		n=seq.notes[track][ni];
-	}
-	while(ni!=seq.noteIndex[track]+1 && n==SEQ_NOTE_TIE);
-	
-	// silence it, in case it's not a rest
-	
-	if(n!=SEQ_NOTE_TIE && n!=SEQ_NOTE_REST)
-	{
-		assigner_assignNote(n+seq.previousTranspose[track],0,0);
-		
+
+	s=seq.events[track][seq.prevEventIndex[track]];
+	do {
+		s&=SEQ_NOTEBITS;
+
+		if(s==SEQ_REST||s==SEQ_TIE)
+			break;
+
+		// handle notes
+		n=s+SCANNER_BASE_NOTE+seq.previousTranspose[track];
+
+		// send note to assigner, velocity at half (MIDI value 64)
+		assigner_assignNote(n,0,0);
+
 		// pass to MIDI out
-		midi_sendNoteEvent(n+seq.previousTranspose[track],0,0);
-	}
+		midi_sendNoteEvent(n,0,0);
+
+		seq.prevEventIndex[track]=(seq.prevEventIndex[track]+1)%seq.eventCount[track];
+		s=seq.events[track][seq.prevEventIndex[track]];
+	} while(s&SEQ_CONT);
 }
 
 inline void seq_setMode(int8_t track, seqMode_t mode)
 {
 	seqMode_t oldMode=seq.mode[track];
-	
+
 	if(mode==oldMode)
 		return;
 
 	if(oldMode==smOff)
 	{
 		// load sequence from storage on start
-		if(!storage_loadSequencer(track,seq.notes[track],SEQ_NOTE_MEMORY))
-			memset(seq.notes[track],ASSIGNER_NO_NOTE,SEQ_NOTE_MEMORY);
+		if(!storage_loadSequencer(track,seq.events[track],SEQ_NOTE_MEMORY))
+			memset(seq.events[track],ASSIGNER_NO_NOTE,SEQ_NOTE_MEMORY);
 
-		// compute note count
-		seq.noteCount[track]=SEQ_NOTE_MEMORY;
-		while(seq.noteCount[track] && seq.notes[track][seq.noteCount[track]-1]==ASSIGNER_NO_NOTE)
-			--seq.noteCount[track];
+		// compute note and step count
+		seq.eventCount[track]=0;
+		seq.stepCount[track]=0;
+		while(seq.eventCount[track]<SEQ_NOTE_MEMORY)
+		{
+			uint8_t s=seq.events[track][seq.eventCount[track]];
+			if(!(s&SEQ_CONT))
+				seq.stepCount[track]++;
+			if(s==ASSIGNER_NO_NOTE)
+				break;
+			seq.eventCount[track]++;
+		}
 	}
 	else if(oldMode==smRecording)
 	{
 		// store sequence to storage on record end
-		storage_saveSequencer(track,seq.notes[track],SEQ_NOTE_MEMORY);
+		storage_saveSequencer(track,seq.events[track],SEQ_NOTE_MEMORY);
 	}
 	else if(oldMode==smPlaying)
 	{
-		finishPreviousNote(track,0);
+		finishPreviousNotes(track);
 	}	
-	
+
 	if(mode==smPlaying)
 		seq_resetCounter(track);
+
+	if(mode==smRecording)
+		seq.addTies=0;
 
 	seq.mode[track]=mode;
 }
@@ -101,14 +116,15 @@ FORCEINLINE void seq_setTranspose(int8_t transpose)
 
 FORCEINLINE void seq_resetCounter(int8_t track)
 {
-	seq.noteIndex[track]=-1; // reinit
+	seq.eventIndex[track]=0; // reinit
 	seq.counter=INT16_MAX; // start on a note
+	seq.prevEventIndex[track]=-1;
 }
 
 void seq_silence(int8_t track)
 {
 	if(seq.mode[track]==smPlaying)
-		finishPreviousNote(track,0);
+		finishPreviousNotes(track);
 }
 
 FORCEINLINE seqMode_t seq_getMode(int8_t track)
@@ -116,40 +132,168 @@ FORCEINLINE seqMode_t seq_getMode(int8_t track)
 	return seq.mode[track];
 }
 
-FORCEINLINE uint8_t seq_getNoteCount(int8_t track)
+FORCEINLINE uint8_t seq_getStepCount(int8_t track)
 {
-	return seq.noteCount[track];
+	return seq.stepCount[track];
 }
 
-void seq_inputNote(uint8_t note)
+FORCEINLINE int8_t seq_full(int8_t track)
+{
+	return seq.eventCount[track]+seq.addTies>=SEQ_NOTE_MEMORY;
+}
+
+static FORCEINLINE void noteOnCount(void)
+{
+	seq.noteOns++;
+}
+
+static FORCEINLINE void noteOffCount(void)
+{
+	if (seq.noteOns) // should not be needed, but for robustness
+		seq.noteOns--;
+}
+
+static int8_t spaceAvail(int8_t track)
+{
+  // We need to have space not only for notes but also for any added
+  // tie events.
+  return seq.eventCount[track]+seq.addTies<SEQ_NOTE_MEMORY;
+}
+
+void seq_inputNote(uint8_t note, uint8_t pressed)
 {
 	for(int8_t track=0;track<SEQ_TRACK_COUNT;++track)
 	{
 		if(seq.mode[track]!=smRecording)
 			continue;
-		
+
 		if(note==SEQ_NOTE_CLEAR)
 		{
-			seq.noteCount[track]=0;
-			memset(seq.notes[track],ASSIGNER_NO_NOTE,SEQ_NOTE_MEMORY);
+			seq.eventCount[track]=0;
+			seq.stepCount[track]=0;
+			seq.addTies=0;
+			memset(seq.events[track],ASSIGNER_NO_NOTE,SEQ_NOTE_MEMORY);
 		}
 		else if(note==SEQ_NOTE_UNDO)
 		{
-			if(seq.noteCount[track])
-				seq.notes[track][--seq.noteCount[track]]=ASSIGNER_NO_NOTE;
+			if(!seq.stepCount[track]) /* break if no events */
+				continue;
+			seq.stepCount[track]--; /* back up one step */
+			if (seq.addTies) /* currently entering tie */
+			{
+				seq.addTies--;
+				continue;
+			}
+			if (seq.noteOns) /* any notes down? */
+			{
+				/* erase from entry buffer */
+				while (seq.eventCount[track])
+					seq.events[track][--seq.eventCount[track]]=ASSIGNER_NO_NOTE;
+				seq.noteOns=0; /* a bit of a kludge */
+				/* but since we've deleted the current entry,
+				 * for all practical purposes there are no
+				 * keys down now. */
+				continue;
+			}
+			/* erase all events back to previous one */
+			while(seq.eventCount[track])
+			{
+				uint8_t s=seq.events[track][--seq.eventCount[track]];
+				seq.events[track][seq.eventCount[track]]=ASSIGNER_NO_NOTE;
+				if(!(s&SEQ_CONT))
+					break;
+			}
+		}
+		else if(note==SEQ_NOTE_STEP)
+		{
+			/* If there are no events, simply insert a rest event.
+			 * Otherwise we bump the #ties counter . */
+			/* TODO: use bit 6 for rest events, with lower bits
+			 * a counter? In that case we insert one if there
+			 * isn't one already, otherwise bump it. */
+			if(!spaceAvail(track))
+				continue;
+			seq.stepCount[track]++;
+			if (!seq.noteOns) // no notes down => add rest
+			{
+				seq.events[track][seq.eventCount[track]]=SEQ_REST;
+				seq.eventCount[track]++;
+			}
+			else // just count tie events to be added later
+				seq.addTies++;
 		}
 		else
 		{
-			if(seq.noteCount[track]<SEQ_NOTE_MEMORY)
-				seq.notes[track][seq.noteCount[track]++]=note;
+			if (pressed) {
+				int8_t first=!seq.noteOns; /* first of chord*/
+				seq.noteOns++;
+				/* TODO: We need to check if the note already
+				 * exists in this event; if so, it means it
+				 * released and pressed again, and we don't
+				 * need to / shouldn't add it. */
+				if(spaceAvail(track))
+				{
+					seq.events[track][seq.eventCount[track]++]=(note-SCANNER_BASE_NOTE)|(first?0:SEQ_CONT);
+					if (first)
+						seq.stepCount[track]++;
+				}
+			}
+			else
+			{
+				if (seq.noteOns)
+					seq.noteOns--;
+				if(!seq.noteOns) /* last note released */
+				{
+					// additional tie events
+					// We know there's space for these,
+					// as spaceAvail() takes it into account
+					/* TODO: use bit 6 for counter,
+					 * thus we just insert one event for
+					 * up to 64 extra steps? */
+					memset(&seq.events[track][seq.eventCount[track]],SEQ_TIE,seq.addTies);
+					seq.eventCount[track]+=seq.addTies;
+					seq.addTies=0;
+					/* seq.addTies is now 0 */
+				}
+			}
 		}
 	}
 }
 
+static FORCEINLINE void playStep(int8_t track)
+{
+	uint8_t s,n;
+
+	s=seq.events[track][seq.eventIndex[track]];
+	if(s!=SEQ_TIE) // terminate previous unless it's a tie
+		finishPreviousNotes(track);
+	if(s!=SEQ_REST&&s!=SEQ_TIE) /* a note */
+	{
+		// save note index so we can do note off later
+		seq.prevEventIndex[track]=seq.eventIndex[track];
+		seq.previousTranspose[track]=seq.transpose;
+	}
+	do {
+		s&=SEQ_NOTEBITS;
+		if(s!=SEQ_REST&&s!=SEQ_TIE) /* a note */
+		{	
+			// handle notes
+			n=s+SCANNER_BASE_NOTE+seq.transpose;
+
+			// send note to assigner, velocity at half (MIDI value 64)
+			assigner_assignNote(n,1,HALF_RANGE);
+
+			// pass to MIDI out
+			midi_sendNoteEvent(n,1,HALF_RANGE);
+
+		}
+		seq.eventIndex[track]=(seq.eventIndex[track]+1)%seq.eventCount[track];
+		s=seq.events[track][seq.eventIndex[track]];
+	} while(s&SEQ_CONT);
+}
+
 void seq_update(void)
 {
-	uint8_t n;
-	
 	// speed management
 
 	if(seq.speed==UINT16_MAX)
@@ -171,43 +315,22 @@ void seq_update(void)
 
 		// nothing to play ?
 
-		if(!seq.noteCount[track])
+		if(!seq.eventCount[track])
 			continue;
 
-		// to next note
-		
-		seq.noteIndex[track]=(seq.noteIndex[track]+1)%seq.noteCount[track];
-		n=seq.notes[track][seq.noteIndex[track]];
-
-		// handle note
-
-		if(n!=SEQ_NOTE_TIE)
-		{
-			finishPreviousNote(track,-1);
-		}
-		
-		if(n!=SEQ_NOTE_TIE && n!=SEQ_NOTE_REST)
-		{
-			// send note to assigner, velocity at half (MIDI value 64)
-			assigner_assignNote(n+seq.transpose,1,HALF_RANGE);
-
-			// pass to MIDI out
-			midi_sendNoteEvent(n+seq.transpose,1,HALF_RANGE);
-		
-			seq.previousTranspose[track]=seq.transpose;
-		}
+		playStep(track);
 	}
 }
 
 void seq_init(void)
 {
 	int8_t track;
-	
+
 	memset(&seq,0,sizeof(seq));
 
 	for(track=0;track<SEQ_TRACK_COUNT;++track)
 	{
-		seq.noteIndex[track]=-1;
-		memset(seq.notes[track],ASSIGNER_NO_NOTE,SEQ_NOTE_MEMORY);
+		seq.eventIndex[track]=0;
+		memset(seq.events[track],ASSIGNER_NO_NOTE,SEQ_NOTE_MEMORY);
 	}		
 }

--- a/common/seq.c
+++ b/common/seq.c
@@ -8,6 +8,8 @@
 #include "assigner.h"
 #include "storage.h"
 #include "midi.h"
+#include "clock.h"
+#include "arp.h"
 
 struct track
 {
@@ -25,7 +27,6 @@ static struct
 	struct track tracks[SEQ_TRACK_COUNT];
 
 	int8_t transpose;
-	uint16_t counter,speed;
 	// During note entry:
 	uint8_t addTies; // how many ties to add
 	uint8_t noteOns; // how many keys are down
@@ -176,18 +177,9 @@ inline void seq_setMode(int8_t track, seqMode_t mode)
 	// sequence is started after the first has already played (at least)
 	// one step), so we don't play the step here, but let it be played
 	// as usual from seq_update().
-	if(mode==smPlaying&&alreadyPlaying&&seq.speed!=UINT16_MAX&&seq.counter<seq.speed/2)
+	uint16_t speed=clock_getSpeed();
+	if(mode==smPlaying&&alreadyPlaying&&speed!=UINT16_MAX&&clock_getCounter()<speed/2)
 		playStep(track);
-}
-
-inline void seq_setSpeed(uint16_t speed)
-{
-	if(speed<1024)
-		seq.speed=UINT16_MAX;
-	else if(settings.syncMode==smInternal)
-		seq.speed=exponentialCourse(speed,22000.0f,500.0f);
-	else
-		seq.speed=extClockDividers[((uint32_t)speed*(sizeof(extClockDividers)/sizeof(uint16_t)))>>16];
 }
 
 FORCEINLINE void seq_setTranspose(int8_t transpose)
@@ -206,8 +198,8 @@ FORCEINLINE void seq_resetCounter(int8_t track)
 	seq_silence(track);
 	seq.tracks[track].eventIndex=0; // reinit
 	seq.tracks[track].prevEventIndex=-1;
-	if(!anyTrackPlaying())
-		seq.counter=INT16_MAX; // start on a note
+	if(!anyTrackPlaying()&&arp_getMode()==amOff)
+		clock_reset(); // start on a note
 }
 
 FORCEINLINE seqMode_t seq_getMode(int8_t track)
@@ -343,18 +335,6 @@ void seq_inputNote(uint8_t note, uint8_t pressed)
 
 void seq_update(void)
 {
-	// speed management
-
-	if(seq.speed==UINT16_MAX)
-		return;
-
-	++seq.counter;
-
-	if(seq.counter<seq.speed)
-		return;
-
-	seq.counter=0;
-
 	for(int8_t track=0;track<SEQ_TRACK_COUNT;++track)
 		playStep(track);
 }

--- a/common/seq.c
+++ b/common/seq.c
@@ -227,10 +227,22 @@ static FORCEINLINE void inputNote(struct track *tp, uint8_t note, uint8_t presse
 		seq.noteOns++;
 		if(!spaceAvail(tp))
 			return;
-		tp->events[tp->eventCount++]=(note-SCANNER_BASE_NOTE)|(first?0:SEQ_CONT);
+		note-=SCANNER_BASE_NOTE;
 		// Advance step count when we hit first note of a chord.
 		if (first)
 			tp->stepCount++;
+		else
+		{
+			// check for duplicates
+			int8_t searchIndex=tp->eventCount-1;
+			uint8_t event;
+			do {
+				event=tp->events[searchIndex];
+				if((event&SEQ_NOTEBITS)==note)
+					return; // duplicate, so don't use
+			} while((event&SEQ_CONT)&&--searchIndex>=0);
+		}
+		tp->events[tp->eventCount++]=note|(first?0:SEQ_CONT);
 	}
 	else
 	{

--- a/common/seq.c
+++ b/common/seq.c
@@ -156,7 +156,7 @@ inline void seq_setMode(int8_t track, seqMode_t mode)
 	}	
 
 	if(mode==smPlaying)
-		seq_resetCounter(track);
+		seq_resetCounter(track,settings.syncMode==smInternal);
 
 	if(mode==smRecording)
 		seq.addTies=0;
@@ -193,13 +193,13 @@ FORCEINLINE void seq_silence(int8_t track)
 		finishPreviousNotes(&seq.tracks[track]);
 }
 
-FORCEINLINE void seq_resetCounter(int8_t track)
+FORCEINLINE void seq_resetCounter(int8_t track, int8_t beatReset)
 {
 	seq_silence(track);
 	seq.tracks[track].eventIndex=0; // reinit
 	seq.tracks[track].prevEventIndex=-1;
-	if(!anyTrackPlaying()&&arp_getMode()==amOff)
-		clock_reset(); // start on a note
+	if(beatReset&&!anyTrackPlaying()&&arp_getMode()==amOff)
+		clock_reset(); // start immediately
 }
 
 FORCEINLINE seqMode_t seq_getMode(int8_t track)

--- a/common/seq.c
+++ b/common/seq.c
@@ -195,18 +195,19 @@ FORCEINLINE void seq_setTranspose(int8_t transpose)
 	seq.transpose=transpose;
 }
 
+FORCEINLINE void seq_silence(int8_t track)
+{
+	if(seq.tracks[track].mode==smPlaying)
+		finishPreviousNotes(&seq.tracks[track]);
+}
+
 FORCEINLINE void seq_resetCounter(int8_t track)
 {
+	seq_silence(track);
 	seq.tracks[track].eventIndex=0; // reinit
 	seq.tracks[track].prevEventIndex=-1;
 	if(!anyTrackPlaying())
 		seq.counter=INT16_MAX; // start on a note
-}
-
-void seq_silence(int8_t track)
-{
-	if(seq.tracks[track].mode==smPlaying)
-		finishPreviousNotes(&seq.tracks[track]);
 }
 
 FORCEINLINE seqMode_t seq_getMode(int8_t track)

--- a/common/seq.h
+++ b/common/seq.h
@@ -42,7 +42,7 @@ void seq_setTranspose(int8_t transpose);
 seqMode_t seq_getMode(int8_t track);
 uint8_t seq_getStepCount(int8_t track);
 int8_t seq_full(int8_t track);
-void seq_resetCounter(int8_t track);
+void seq_resetCounter(int8_t track, int8_t beatReset);
 void seq_silence(int8_t track);
 
 void seq_inputNote(uint8_t note, uint8_t pressed);

--- a/common/seq.h
+++ b/common/seq.h
@@ -3,13 +3,29 @@
 
 #include "synth.h"
 
+// Sequencer event list definitions
+
+#define SEQ_NOTEBITS 0x3f /* bits 0..5 */
+
+// event is a continuation of previous event - only used for notes
+#define SEQ_CONT 128 /* bit 7 */
+
+/* These must be > highest note which is 60 */
+// A lone rest means an unused entry (i.e. at the end of the sequence).
+// In a valid sequence a rest always is the first (and only) entry in a step,
+// consequently it always comes with SEQ_CONT clear.
+#define SEQ_REST (ASSIGNER_NO_NOTE&0x3f)
+// A tie extends the timing of the previous step
+#define SEQ_TIE (SEQ_REST-1)
+
+// sequencer config
 #define SEQ_NOTE_MEMORY 128
 #define SEQ_TRACK_COUNT 2
 
-#define SEQ_NOTE_REST UINT8_MAX-1
-#define SEQ_NOTE_TIE UINT8_MAX-2
-#define SEQ_NOTE_UNDO UINT8_MAX-3
-#define SEQ_NOTE_CLEAR UINT8_MAX-4
+// Codes from keypad presses
+#define SEQ_NOTE_STEP UINT8_MAX-1
+#define SEQ_NOTE_UNDO UINT8_MAX-2
+#define SEQ_NOTE_CLEAR UINT8_MAX-3
 
 typedef enum
 {
@@ -24,11 +40,12 @@ void seq_setMode(int8_t track, seqMode_t mode);
 void seq_setSpeed(uint16_t speed);
 void seq_setTranspose(int8_t transpose);
 seqMode_t seq_getMode(int8_t track);
-uint8_t seq_getNoteCount(int8_t track);
+uint8_t seq_getStepCount(int8_t track);
+int8_t seq_full(int8_t track);
 void seq_resetCounter(int8_t track);
 void seq_silence(int8_t track);
 
-void seq_inputNote(uint8_t note);
+void seq_inputNote(uint8_t note, uint8_t pressed);
 
 #endif	/* SEQ_H */
 

--- a/common/synth.c
+++ b/common/synth.c
@@ -560,9 +560,10 @@ static void refreshSevenSeg(void)
 	if(seq_getMode(0)==smRecording || seq_getMode(1)==smRecording)
 	{
 		int8_t track=(seq_getMode(1)==smRecording)?1:0;
-		uint8_t count=seq_getNoteCount(track);
+		uint8_t count=seq_getStepCount(track);
+		int8_t full=seq_full(track);
 		sevenSeg_setNumber(count);
-		led_set(plDot,count>=100,count==SEQ_NOTE_MEMORY);
+		led_set(plDot,count>=100||full,full);
 	}
 	else if(ui.digitInput<diLoadDecadeDigit)
 	{
@@ -1131,9 +1132,9 @@ void synth_keyEvent(uint8_t key, int pressed)
 		if(arp_getMode()==amOff)
 		{
 			// sequencer note input		
-			if(pressed && (seq_getMode(0)==smRecording || seq_getMode(1)==smRecording))
+			if(seq_getMode(0)==smRecording || seq_getMode(1)==smRecording)
 			{
-				seq_inputNote(key);
+				seq_inputNote(key, pressed);
 				refreshSevenSeg();
 			}
 

--- a/common/synth.c
+++ b/common/synth.c
@@ -22,6 +22,7 @@
 #include "midi.h"
 #include "../xnormidi/midi.h"
 #include "seq.h"
+#include "clock.h"
 
 #define POT_DEAD_ZONE 512
 
@@ -944,10 +945,9 @@ void synth_update(void)
 		synth.glideAmount=exponentialCourse(currentPreset.continuousParameters[cpGlide],11000.0f,2100.0f);
 		synth.gliding=synth.glideAmount<2000;
 		
-		// arp
+		// arp and seq
 		
-		arp_setSpeed(currentPreset.continuousParameters[cpSeqArpClock]);
-		seq_setSpeed(currentPreset.continuousParameters[cpSeqArpClock]);
+		clock_setSpeed(currentPreset.continuousParameters[cpSeqArpClock]);
 		
 		break;
 	}
@@ -1052,15 +1052,18 @@ void synth_timerInterrupt(void)
 			if(synth.pendingExtClock)
 				--synth.pendingExtClock;
 
-			// sequencer
+			if (clock_update())
+			{
+				// sequencer
 
-			if(seq_getMode(0)!=smOff || seq_getMode(1)!=smOff)
-				seq_update();
+				if(seq_getMode(0)!=smOff || seq_getMode(1)!=smOff)
+					seq_update();
 			
-			// arpeggiator
+				// arpeggiator
 
-			if(arp_getMode()!=amOff)
-				arp_update();
+				if(arp_getMode()!=amOff)
+					arp_update();
+			}
 		}
 
 		// glide

--- a/common/synth.c
+++ b/common/synth.c
@@ -1234,9 +1234,10 @@ void synth_realtimeEvent(uint8_t midiEvent)
 			++synth.pendingExtClock;
 			break;
 		case MIDI_START:
-			seq_resetCounter(0);
-			seq_resetCounter(1);
-			arp_resetCounter();
+			seq_resetCounter(0,0);
+			seq_resetCounter(1,0);
+			arp_resetCounter(0);
+			clock_reset(); // always do a beat reset on MIDI START
 			synth.pendingExtClock=0;
 			break;
 		case MIDI_STOP:

--- a/common/ui.c
+++ b/common/ui.c
@@ -373,7 +373,6 @@ static LOWERCODESIZE void handleSequencerPage(p600Button_t button)
 		{
 		case pb0:
 			note=SEQ_NOTE_CLEAR;
-			sevenSeg_scrollText("clear",1);
 			break;
 		case pb1:
 			note=SEQ_NOTE_UNDO;

--- a/common/ui.c
+++ b/common/ui.c
@@ -375,23 +375,18 @@ static LOWERCODESIZE void handleSequencerPage(p600Button_t button)
 			note=SEQ_NOTE_CLEAR;
 			sevenSeg_scrollText("clear",1);
 			break;
-		case pb3:
-			note=SEQ_NOTE_REST;
-			sevenSeg_scrollText("rest",1);
-			break;
-		case pb2:
-			note=SEQ_NOTE_TIE;
-			sevenSeg_scrollText("tie",1);
-			break;
 		case pb1:
 			note=SEQ_NOTE_UNDO;
+			break;
+		case pb2:
+			note=SEQ_NOTE_STEP;
 			break;
 		default:
 			note=ASSIGNER_NO_NOTE;
 		}
 		
 		if(note!=ASSIGNER_NO_NOTE)
-			seq_inputNote(note);
+			seq_inputNote(note,1);
 	}
 }
 

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -62,6 +62,7 @@ SRC = \
 	../common/sh.c \
 	../common/adsr.c \
 	../common/lfo.c \
+	../common/clock.c \
 	../common/arp.c \
 	../common/seq.c \
 	../common/tuner.c \

--- a/firmware/p600firmware.c
+++ b/firmware/p600firmware.c
@@ -10,6 +10,8 @@
 
 #include "synth.h"
 
+#define CLOBBERED(reg)	__asm__ __volatile__ ("" : : : reg);
+
 #define CPU_PRESCALE(n)	(CLKPR = 0x80, CLKPR = (n))
 #define CPU_16MHz       0x00
 #define CPU_8MHz        0x01
@@ -521,6 +523,12 @@ void storage_write(uint32_t pageIdx, uint8_t *buf)
 	if(pageIdx<(STORAGE_SIZE/STORAGE_PAGE_SIZE))
 	{
 		blHack_program_page(pageIdx*STORAGE_PAGE_SIZE+STORAGE_ADDR,buf);
+
+		// Somewhere R16 appears to get clobbered even though the
+		// compiler is not aware of it, possibly in the SPM routine
+		// called by blHack_call_SPM. So to avoid potential problems
+		// in callers higher up in the stack we mark R16 as clobbered here.
+		CLOBBERED("r16");
 	}
 }
 


### PR DESCRIPTION
Added synchronization between sequencer and arpeggiator so they always run in sync (i.e. the notes from both trigger at the same time, regardless of exactly when the user presses SEQx or starts the arpeggio).

Tested with internal sync and midi sync, but not with tape sync.

Note, based on the polyseq branch.