### PR TITLE
Uncomment tuningName to fix DEBUG build

### DIFF
--- a/common/midi.c
+++ b/common/midi.c
@@ -117,7 +117,7 @@ static void mtsReceiveBulkTuningDump(uint8_t * buf, int16_t size)
 		return;
 	}
 	
-	//char * tuningName = (char *)&buf[1]; // 16 byte 'tuning name'
+	char * tuningName = (char *)&buf[1]; // 16 byte 'tuning name'
 	semitone_t *semitones = (semitone_t *)&buf[17]; // 128 in length	
 
 	// FIXME: do something with these...

--- a/common/midi.c
+++ b/common/midi.c
@@ -117,7 +117,6 @@ static void mtsReceiveBulkTuningDump(uint8_t * buf, int16_t size)
 		return;
 	}
 	
-	char * tuningName = (char *)&buf[1]; // 16 byte 'tuning name'
 	semitone_t *semitones = (semitone_t *)&buf[17]; // 128 in length	
 
 	// FIXME: do something with these...
@@ -130,6 +129,8 @@ static void mtsReceiveBulkTuningDump(uint8_t * buf, int16_t size)
 	int i;
 	
 #ifdef DEBUG
+	char * tuningName = (char *)&buf[1]; // 16 byte 'tuning name'	
+	
 	print("Loading tuning: '");
 	for(i=0; i < 16; i++) {
 		pchar(tuningName[i]);

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -176,6 +176,7 @@ CFLAGS += -fpack-struct
 CFLAGS += -fshort-enums
 CFLAGS += -Wall
 CFLAGS += -Wstrict-prototypes
+CFLAGS += -Werror
 #CFLAGS += -mshort-calls
 #CFLAGS += -fno-unit-at-a-time
 #CFLAGS += -Wundef

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -176,7 +176,6 @@ CFLAGS += -fpack-struct
 CFLAGS += -fshort-enums
 CFLAGS += -Wall
 CFLAGS += -Wstrict-prototypes
-CFLAGS += -Werror
 #CFLAGS += -mshort-calls
 #CFLAGS += -fno-unit-at-a-time
 #CFLAGS += -Wundef


### PR DESCRIPTION
The #define DEBUG build was broken when I commented out a variable name used in debug print messages. This fixes the build when DEBUG=1.