### PR TITLE
Fix #67, #64, #43 and #69

### DIFF
--- a/common/arp.c
+++ b/common/arp.c
@@ -45,7 +45,7 @@ static void finishPreviousNote(void)
 	{
 		uint8_t n=arp.previousNote&~ARP_NOTE_HELD_FLAG;
 		
-		assigner_assignNote(n+SCANNER_BASE_NOTE+arp.previousTranspose,0,0);
+		assigner_assignNote(n+SCANNER_BASE_NOTE+arp.previousTranspose,0,0,0);
 		
 		// pass to MIDI out
 		midi_sendNoteEvent(n+SCANNER_BASE_NOTE+arp.previousTranspose,0,0);
@@ -241,7 +241,7 @@ void arp_update(void)
 	
 	// send note to assigner, velocity at half (MIDI value 64)
 	
-	assigner_assignNote(n+SCANNER_BASE_NOTE+arp.transpose,1,HALF_RANGE);
+	assigner_assignNote(n+SCANNER_BASE_NOTE+arp.transpose,1,HALF_RANGE,0);
 	
 	// pass to MIDI out
 

--- a/common/arp.c
+++ b/common/arp.c
@@ -60,7 +60,7 @@ static void killAllNotes(void)
 	arp.previousNote=ASSIGNER_NO_NOTE;
 
 	memset(arp.notes,ASSIGNER_NO_NOTE,ARP_NOTE_MEMORY);
-	assigner_voiceDone(-1);
+	assigner_allNotesOff();
 }
 
 static void killHeldNotes(void)

--- a/common/arp.c
+++ b/common/arp.c
@@ -60,7 +60,7 @@ static void killAllNotes(void)
 	arp.previousNote=ASSIGNER_NO_NOTE;
 
 	memset(arp.notes,ASSIGNER_NO_NOTE,ARP_NOTE_MEMORY);
-	assigner_allNotesOff();
+	assigner_allKeysOff();
 }
 
 static void killHeldNotes(void)

--- a/common/assigner.c
+++ b/common/assigner.c
@@ -2,6 +2,7 @@
 // Voice assigner
 ////////////////////////////////////////////////////////////////////////////////
 
+#include "scanner.h"
 #include "assigner.h"
 
 struct allocation_s
@@ -382,12 +383,15 @@ void assigner_voiceDone(int8_t voice)
 
 // This is different from assigner_voiceDone(-1) in that it does note silence
 // the voice immediately but lets it go through its release phase as usual.
-void assigner_allNotesOff(void)
+// Also, only voices corresponding to keys that are down on the keyboard
+// are released.
+void assigner_allKeysOff(void)
 {
 	int8_t v;
 	for(v=0;v<SYNTH_VOICE_COUNT;++v)
 	{
-		if (!isVoiceDisabled(v) && assigner.allocation[v].gated)
+		if (!isVoiceDisabled(v) && assigner.allocation[v].gated &&
+		    scanner_isKeyDown(assigner.allocation[v].rootNote))
 		{
 			synth_assignerEvent(assigner.allocation[v].note,0,v,assigner.allocation[v].velocity,0);
 		    	assigner.allocation[v].gated=0;

--- a/common/assigner.c
+++ b/common/assigner.c
@@ -187,7 +187,7 @@ void assigner_voiceDone(int8_t voice)
 	assigner.allocation[voice].rootNote=ASSIGNER_NO_NOTE;
 }
 
-static void voicesDone(void)
+static void voicesDone(int8_t releaseNotes)
 {
 	int8_t v;
 	for(v=0;v<SYNTH_VOICE_COUNT;++v)
@@ -195,11 +195,12 @@ static void voicesDone(void)
 		assigner_voiceDone(v);
 		assigner.allocation[v].timestamp=0; // reset to voice 0 in case all voices stopped at once
 	}
-	// If we have requested all voices to silence, we probably want to
-	// clear all pending key status too, or we might get a note
-	// seemingly popping up from nowhere later on if there are keys
-	// to release after this call has been performed.
-	memset(assigner.noteStates, 0, sizeof(assigner.noteStates));
+	if (releaseNotes)
+		// If we have requested all voices to silence, we might want to
+		// clear all pending key status too, or we might get a note
+		// seemingly popping up from nowhere later on if there are keys
+		// to release after this call has been performed.
+		memset(assigner.noteStates, 0, sizeof(assigner.noteStates));
 }
 
 // This is different from voicesDone() in that it does not silence
@@ -219,7 +220,9 @@ void assigner_allKeysOff(void)
 		    	assigner.allocation[v].keyPressed=0;
 		}
 	}
-	// Release all keys and future holds too
+	// Release all keys and future holds too. This avoids potential
+	// problems with notes seemingly popping up from nowhere due to
+	// reassignment when future keys are released.
 	memset(assigner.noteStates, 0, sizeof(assigner.noteStates));
 	assigner.hold=0;
 }
@@ -229,7 +232,7 @@ void assigner_setPriority(assignerPriority_t prio)
 	if(prio==assigner.priority)
 		return;
 	
-	voicesDone();
+	voicesDone(1);
 	
 	if(prio>2)
 		prio=0;
@@ -242,7 +245,7 @@ void assigner_setVoiceMask(uint8_t mask)
 	if(mask==assigner.voiceMask)
 		return;
 	
-	voicesDone();
+	voicesDone(1);
 	assigner.voiceMask=mask;
 }
 
@@ -424,7 +427,13 @@ LOWERCODESIZE void assigner_setPattern(uint8_t * pattern, int8_t mono)
 		return;
 
 	if(mono!=assigner.mono)
-		voicesDone();
+		// We don't want to clear the note status in this case,
+		// as the result would be that if we get any contact bounce
+		// in the Unison switch, we will get Unison rather than
+		// Chord Memory if there are keys held, as the keys would have
+		// been considered released by the time the second bounce to
+		// the Unison position was registered.
+		voicesDone(0);
 	
 	assigner.mono=mono;
 	memset(&assigner.patternOffsets[0],ASSIGNER_NO_NOTE,SYNTH_VOICE_COUNT);

--- a/common/assigner.c
+++ b/common/assigner.c
@@ -380,6 +380,19 @@ void assigner_voiceDone(int8_t voice)
 		}
 }
 
+// This is different from assigner_voiceDone(-1) in that it does a 'proper'
+// key assignment, releasing all notes that are on.
+void assigner_allNotesOff(void)
+{
+	uint8_t note;
+
+	for (note=0;note<128;note++)
+	{
+		if(getNoteState(note))
+			assigner_assignNote(note,0,0);
+	}
+}
+
 LOWERCODESIZE void assigner_setPattern(uint8_t * pattern, int8_t mono)
 {
 	int8_t i,count=0;

--- a/common/assigner.c
+++ b/common/assigner.c
@@ -381,6 +381,12 @@ void assigner_voiceDone(int8_t voice)
 			if(voice<0)
 				assigner.allocation[v].timestamp=0; // reset to voice 0 in case all voices stopped at once
 		}
+	// If we have requested all voices to silence, we probably want to
+	// clear any pending key assignments too, or we might get a note
+	// seemingly popping up from nowhere later on if there are keys
+	// to release.
+	if (voice==-1)
+		memset(assigner.noteStates, 0, sizeof(assigner.noteStates));
 }
 
 // This is different from assigner_voiceDone(-1) in that it does note silence

--- a/common/assigner.c
+++ b/common/assigner.c
@@ -14,6 +14,7 @@ struct allocation_s
 	int8_t assigned;
 	int8_t gated;
 	int8_t keyPressed;
+	int8_t internalKeyboard;
 };
 
 static struct
@@ -231,7 +232,7 @@ int8_t assigner_getAnyAssigned(void)
 	return v!=0;
 }
 
-void assigner_assignNote(uint8_t note, int8_t gate, uint16_t velocity)
+void assigner_assignNote(uint8_t note, int8_t gate, uint16_t velocity, int8_t keyboard)
 {
 	uint32_t timestamp;
 	uint16_t oldVel;
@@ -301,6 +302,7 @@ reassign:
 			assigner.allocation[v].rootNote=note;
 			assigner.allocation[v].note=n;
 			assigner.allocation[v].timestamp=timestamp;
+			assigner.allocation[v].internalKeyboard=keyboard;
 
 			synth_assignerEvent(n,1,v,velocity,legato);
 
@@ -391,7 +393,7 @@ void assigner_allKeysOff(void)
 	for(v=0;v<SYNTH_VOICE_COUNT;++v)
 	{
 		if (!isVoiceDisabled(v) && assigner.allocation[v].gated &&
-		    scanner_isKeyDown(assigner.allocation[v].rootNote))
+		    assigner.allocation[v].internalKeyboard)
 		{
 			synth_assignerEvent(assigner.allocation[v].note,0,v,assigner.allocation[v].velocity,0);
 		    	assigner.allocation[v].gated=0;

--- a/common/assigner.c
+++ b/common/assigner.c
@@ -380,17 +380,23 @@ void assigner_voiceDone(int8_t voice)
 		}
 }
 
-// This is different from assigner_voiceDone(-1) in that it does a 'proper'
-// key assignment, releasing all notes that are on.
+// This is different from assigner_voiceDone(-1) in that it does note silence
+// the voice immediately but lets it go through its release phase as usual.
 void assigner_allNotesOff(void)
 {
-	uint8_t note;
-
-	for (note=0;note<128;note++)
+	int8_t v;
+	for(v=0;v<SYNTH_VOICE_COUNT;++v)
 	{
-		if(getNoteState(note))
-			assigner_assignNote(note,0,0);
+		if (!isVoiceDisabled(v) && assigner.allocation[v].gated)
+		{
+			synth_assignerEvent(assigner.allocation[v].note,0,v,assigner.allocation[v].velocity,0);
+		    	assigner.allocation[v].gated=0;
+		    	assigner.allocation[v].keyPressed=0;
+		}
 	}
+	// Release all keys and future holds too
+	memset(assigner.noteStates, 0, sizeof(assigner.noteStates));
+	assigner.hold=0;
 }
 
 LOWERCODESIZE void assigner_setPattern(uint8_t * pattern, int8_t mono)

--- a/common/assigner.h
+++ b/common/assigner.h
@@ -19,7 +19,7 @@ int8_t assigner_getAnyAssigned(void);
 
 void assigner_assignNote(uint8_t note, int8_t gate, uint16_t velocity);
 void assigner_voiceDone(int8_t voice); // -1 -> all voices finished
-void assigner_allNotesOff(void);
+void assigner_allKeysOff(void);
 
 void assigner_setPattern(uint8_t * pattern, int8_t mono);
 void assigner_getPattern(uint8_t * pattern, int8_t * mono);

--- a/common/assigner.h
+++ b/common/assigner.h
@@ -17,7 +17,7 @@ int8_t assigner_getAssignment(int8_t voice, uint8_t * note);
 int8_t assigner_getAnyPressed(void);
 int8_t assigner_getAnyAssigned(void);
 
-void assigner_assignNote(uint8_t note, int8_t gate, uint16_t velocity);
+void assigner_assignNote(uint8_t note, int8_t gate, uint16_t velocity, int8_t keyboard);
 void assigner_voiceDone(int8_t voice); // -1 -> all voices finished
 void assigner_allKeysOff(void);
 

--- a/common/assigner.h
+++ b/common/assigner.h
@@ -19,6 +19,7 @@ int8_t assigner_getAnyAssigned(void);
 
 void assigner_assignNote(uint8_t note, int8_t gate, uint16_t velocity);
 void assigner_voiceDone(int8_t voice); // -1 -> all voices finished
+void assigner_allNotesOff(void);
 
 void assigner_setPattern(uint8_t * pattern, int8_t mono);
 void assigner_getPattern(uint8_t * pattern, int8_t * mono);

--- a/common/midi.c
+++ b/common/midi.c
@@ -228,7 +228,7 @@ static void midi_noteOnEvent(MidiDevice * device, uint8_t channel, uint8_t note,
 	print("\n");
 #endif
 
-	assigner_assignNote(note,velocity!=0,(((uint32_t)velocity+1)<<9)-1);
+	assigner_assignNote(note,velocity!=0,(((uint32_t)velocity+1)<<9)-1,0);
 }
 
 static void midi_noteOffEvent(MidiDevice * device, uint8_t channel, uint8_t note, uint8_t velocity)
@@ -242,7 +242,7 @@ static void midi_noteOffEvent(MidiDevice * device, uint8_t channel, uint8_t note
 	print("\n");
 #endif
 
-	assigner_assignNote(note,0,0);
+	assigner_assignNote(note,0,0,0);
 }
 
 static void midi_ccEvent(MidiDevice * device, uint8_t channel, uint8_t control, uint8_t value)

--- a/common/scanner.c
+++ b/common/scanner.c
@@ -41,6 +41,13 @@ static FORCEINLINE void scanner_event(uint8_t key, int8_t pressed)
 		synth_keyEvent(key-SCANNER_KEYS_START+SCANNER_BASE_NOTE,pressed);
 }
 
+int8_t scanner_isKeyDown(uint8_t note)
+{
+	if (note<SCANNER_BASE_NOTE || note>SCANNER_C5)
+		return 0;
+	return scanner.state[note-SCANNER_BASE_NOTE+SCANNER_KEYS_START]&1;
+}
+
 void scanner_update(int8_t fullScan)
 {
 	uint8_t i,j,stateIdx;

--- a/common/scanner.h
+++ b/common/scanner.h
@@ -14,6 +14,7 @@ int8_t scanner_buttonState(p600Button_t button);
 
 void scanner_init(void);
 void scanner_update(int8_t fullScan);
+int8_t scanner_isKeyDown(uint8_t note);
 
 #endif	/* SCANNER_H */
 

--- a/common/seq.c
+++ b/common/seq.c
@@ -61,7 +61,7 @@ static void finishPreviousNotes(struct track *tp)
 		n=s+SCANNER_BASE_NOTE+tp->previousTranspose;
 
 		// send note to assigner, velocity at half (MIDI value 64)
-		assigner_assignNote(n,0,0);
+		assigner_assignNote(n,0,0,0);
 
 		// pass to MIDI out
 		midi_sendNoteEvent(n,0,0);
@@ -103,7 +103,7 @@ static FORCEINLINE void playStep(int8_t track)
 			n=s+SCANNER_BASE_NOTE+seq.transpose;
 
 			// send note to assigner, velocity at half (MIDI value 64)
-			assigner_assignNote(n,1,HALF_RANGE);
+			assigner_assignNote(n,1,HALF_RANGE,0);
 
 			// pass to MIDI out
 			midi_sendNoteEvent(n,1,HALF_RANGE);

--- a/common/synth.c
+++ b/common/synth.c
@@ -1152,7 +1152,7 @@ void synth_keyEvent(uint8_t key, int pressed)
 			}
 
 			// set velocity to half (corresponding to MIDI value 64)
-			assigner_assignNote(key+synth.transpose,pressed,HALF_RANGE);
+			assigner_assignNote(key+synth.transpose,pressed,HALF_RANGE,1);
 
 			// pass to MIDI out
 			midi_sendNoteEvent(key+synth.transpose,pressed,HALF_RANGE);

--- a/common/synth.c
+++ b/common/synth.c
@@ -1130,6 +1130,13 @@ void synth_keyEvent(uint8_t key, int pressed)
 			
 			itoa(synth.transpose,&s[9],10);
 			sevenSeg_scrollText(s,1);
+
+			// Disable double-click transpose if transpose is
+			// set using FROM TAPE as shift.
+			// The point of this is to allow user an easy way
+			// out of the toggled double click mode.
+			if (ui.isShifted)
+				ui.isDoubleClicked=0;
 		}
 	}
 	else

--- a/common/synth.c
+++ b/common/synth.c
@@ -626,7 +626,6 @@ static void refreshSevenSeg(void)
 
 	led_set(plPreset,settings.presetMode,0);
 	led_set(plToTape,ui.digitInput==diSynth && settings.presetMode,0);
-	led_set(plFromTape,scanner_buttonState(pbFromTape),0);
 	led_set(plSeq1,seq_getMode(0)!=smOff,seq_getMode(0)!=smPlaying);
 	led_set(plSeq2,seq_getMode(1)!=smOff,seq_getMode(1)!=smPlaying);
 	led_set(plArpUD,arp_getMode()==amUpDown,0);
@@ -1098,6 +1097,8 @@ void synth_timerInterrupt(void)
 		{
 			scanner_update(hz63);
 			display_update(hz63);
+			if (hz63)
+				ui_update();
 		}
 		break;
 	}
@@ -1116,7 +1117,7 @@ void LOWERCODESIZE synth_buttonEvent(p600Button_t button, int pressed)
 
 void synth_keyEvent(uint8_t key, int pressed)
 {
-	if(ui.isShifted)
+	if(ui.isShifted||ui.isDoubleClicked)
 	{
 		// keyboard transposition
 		if(pressed)

--- a/common/tuner.c
+++ b/common/tuner.c
@@ -355,6 +355,9 @@ LOWERCODESIZE static void prepareSynth(void)
 #else
 	sh_setCV(pcMVol,0,0);
 #endif
+	// Update CV's and give final volume VCA CV filter time to close
+	sh_update();
+	MDELAY(150);
 
 	sh_setGate(pgASaw,0);
 	sh_setGate(pgATri,0);

--- a/common/ui.c
+++ b/common/ui.c
@@ -597,11 +597,17 @@ void LOWERCODESIZE ui_handleButton(p600Button_t button, int pressed)
 	{
 		if (pressed)
 		{
-			if (ui.doubleClickTimer)
+			// If we're in double click mode, exit it when
+			// button pressed once. Otherwise enter double click
+			// mode if button pressed < 1 second ago, else it
+			// counts as first time, so set up double click timer.
+			if (ui.isDoubleClicked)
+				ui.isDoubleClicked=0;
+			else if (ui.doubleClickTimer)
 			// Button pressed < 1 second ago
 			{
 				ui.doubleClickTimer=0; // reset timer
-				ui.isDoubleClicked=!ui.isDoubleClicked;
+				ui.isDoubleClicked=1;
 			}
 			else
 				ui.doubleClickTimer = 63; // 1 second
@@ -609,7 +615,7 @@ void LOWERCODESIZE ui_handleButton(p600Button_t button, int pressed)
 		ui.isShifted=pressed;
 		led_set(plFromTape,ui.isShifted||ui.isDoubleClicked,ui.isDoubleClicked);
 		// reset Misc Settings to 'display only' whenever
-		// pbFromTape is released.
+		// pbFromTape is pressed (or released).
 		ui.prevMiscButton=-1;
 	}
 	

--- a/common/ui.c
+++ b/common/ui.c
@@ -595,7 +595,19 @@ void LOWERCODESIZE ui_handleButton(p600Button_t button, int pressed)
 	
 	if(button==pbFromTape)
 	{
+		if (pressed)
+		{
+			if (ui.doubleClickTimer)
+			// Button pressed < 1 second ago
+			{
+				ui.doubleClickTimer=0; // reset timer
+				ui.isDoubleClicked=!ui.isDoubleClicked;
+			}
+			else
+				ui.doubleClickTimer = 63; // 1 second
+		}
 		ui.isShifted=pressed;
+		led_set(plFromTape,ui.isShifted||ui.isDoubleClicked,ui.isDoubleClicked);
 		// reset Misc Settings to 'display only' whenever
 		// pbFromTape is released.
 		ui.prevMiscButton=-1;
@@ -698,4 +710,11 @@ void ui_init(void)
 	ui.presetModified=1;
 	ui.activeParamIdx=-1;
 	ui.prevMiscButton=-1;
+}
+
+// Called at 63Hz
+void ui_update(void)
+{
+	if (ui.doubleClickTimer)
+		ui.doubleClickTimer--;
 }

--- a/common/ui.c
+++ b/common/ui.c
@@ -617,8 +617,14 @@ void LOWERCODESIZE ui_handleButton(p600Button_t button, int pressed)
 	
 	if(pressed)
 	{
-		if(scanner_buttonState(pbFromTape))
+		if(scanner_buttonState(pbFromTape) && button>=pb0 && button<=pb9)
 		{
+			// Disable double click mode which might confuse
+			// user if he presses FROM TAPE within the double
+			// click interval while fiddling with the misc params.
+			ui.doubleClickTimer=0; // reset timer
+			ui.isDoubleClicked=0;
+			led_set(plFromTape,0,0);
 			handleMiscAction(button);
 		}
 		else if(button==pbPreset)

--- a/common/ui.c
+++ b/common/ui.c
@@ -123,12 +123,12 @@ static LOWERCODESIZE void handleMiscAction(p600Button_t button)
 {
 	const char * chs[17]={"omni","ch1","ch2","ch3","ch4","ch5","ch6","ch7","ch8","ch9","ch10","ch11","ch12","ch13","ch14","ch15","ch16"};
 	static int8_t voice=0;
+	uint8_t v;
 	char s[50];
 	
-	
-
-	if(button==pb1) // midi receive channel
+	switch(button)
 	{
+	case pb1: // midi receive channel
 		settings.midiReceiveChannel=((settings.midiReceiveChannel+2)%17)-1;
 		settings_save();
 		
@@ -136,9 +136,8 @@ static LOWERCODESIZE void handleMiscAction(p600Button_t button)
 		strcat(s," recv");
 		
 		sevenSeg_scrollText(s,1);
-	}
-	else if(button==pb2) // midi send channel
-	{
+		break;
+	case pb2: // midi send channel
 		settings.midiSendChannel=(settings.midiSendChannel+1)%16;
 		settings_save();
 		
@@ -146,26 +145,23 @@ static LOWERCODESIZE void handleMiscAction(p600Button_t button)
 		strcat(s," send");
 		
 		sevenSeg_scrollText(s,1);
-	}
-	else if(button==pb3) // pitch wheel calibration
-	{
+		break;
+	case pb3: // pitch wheel calibration
 		settings.benderMiddle=potmux_getValue(ppPitchWheel);
 		settings_save();
 
 		synth_updateBender(); // immediate update
 
 		sevenSeg_scrollText("bender calibrated",1);
-	}
-	else if(button==pb4) // voice selection
-	{
+		break;
+	case pb4: // voice selection
 		voice=(voice+1)%SYNTH_VOICE_COUNT;
 
 		strcpy(s,"Vc-");
 		s[2]='1'+voice;
 		sevenSeg_scrollText(s,1);
-	}
-	else if(button==pb5) // selected voice defeat
-	{
+		break;
+	case pb5: // selected voice defeat
 		if(settings.voiceMask&(1<<voice))
 		{
 			strcpy(s,"Vc- off");
@@ -182,16 +178,14 @@ static LOWERCODESIZE void handleMiscAction(p600Button_t button)
 		s[2]='1'+voice;
 		sevenSeg_scrollText(s,1);
 		refreshFullState();
-	}
-	else if(button==pb6) // preset dump
-	{
+		break;
+	case pb6: // preset dump
 		midi_dumpPresets();
 		sevenSeg_scrollText("presets dumped",1);
 		refreshPresetMode();
 		refreshFullState();
-	}
-	else if(button==pb8) // sync mode
-	{
+		break;
+	case pb8: // sync mode
 		settings.syncMode=(settings.syncMode+1)%3;
 		settings_save();
 		
@@ -209,11 +203,8 @@ static LOWERCODESIZE void handleMiscAction(p600Button_t button)
 		}
 
 		refreshFullState();
-	}
-	else if(button==pb9) // spread / vcf limit
-	{
-		uint8_t v;
-		
+		break;
+	case pb9: // spread / vcf limit
 		v=(settings.spread?1:0)+(settings.vcfLimit?2:0);
 		v=(v+1)%4;
 		settings.spread=v&1;
@@ -246,13 +237,15 @@ static LOWERCODESIZE void handleMiscAction(p600Button_t button)
 		sevenSeg_scrollText(s,1);
 
 		refreshFullState();
-	}
-	else if(button==pb0) // reset to a basic patch
-	{
+		break;
+	case pb0: // reset to a basic patch
 		preset_loadDefault(1);
 		ui.presetModified=1;
 		sevenSeg_scrollText("basic patch",1);
 		refreshFullState();
+		break;
+	default:
+		break;
 	}
 }
 

--- a/common/ui.h
+++ b/common/ui.h
@@ -27,6 +27,9 @@ struct ui_s
 	int32_t previousData;
 	int8_t activeParamIdx;
 	int8_t isShifted;
+
+	p600Button_t prevMiscButton;
+	int8_t voice;
 };
 
 extern struct ui_s ui;

--- a/common/ui.h
+++ b/common/ui.h
@@ -28,6 +28,8 @@ struct ui_s
 	int8_t activeParamIdx;
 	int8_t isShifted;
 
+	int8_t isDoubleClicked;
+	int8_t doubleClickTimer;
 	p600Button_t prevMiscButton;
 	int8_t voice;
 };
@@ -39,6 +41,7 @@ void ui_checkIfDataPotChanged(void);
 void ui_handleButton(p600Button_t button, int pressed);
 void ui_setPresetModified(int8_t modified);
 void ui_setNoActivePot(void);
+void ui_update(void);
 
 #endif	/* UI_H */
 


### PR DESCRIPTION
A bumper package of fixes this time. #67 and #64 were discovered recently. #43 is fairly old but as I understood it you thought was a good idea, so I included it before #69 which I've put last, as I think it may be the most controversial as it introduces a new user interface paradigm: double press. Basically, double pressing ("double clicking") on FROM TAPE goes into transpose mode so that a sequence or arpeggio can be transposed with one hand only, which is handy if the players other hand is busy on another keyboard. It all feels quite natural to me but your opinion may be different.

I've tested it all quite a bit, and so has my friend who owns the P600, but please do give it a thorough test yourself as there might be some function I've missed or not tested without thinking about it.