### PR TITLE
Support firmware build using Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:stable
+
+RUN apt-get update && \
+    apt-get install -y build-essential gcc-avr avr-libc git python2.7 && \
+    ln /usr/bin/python2.7 /usr/bin/python
+
+COPY p600fw-build.sh /bin/p600fw-build
+RUN chmod +x /bin/p600fw-build
+
+CMD [ "/bin/p600fw-build" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,35 @@
+p600fw-builder
+==============
+
+This directory contains a `Dockerfile` that you can use to build the 
+firmware for your Prophet 600 without having to install anything other
+than Docker.
+
+How-To
+------
+
+1. Clone this repo to your local system.
+2. First, install Docker CE; at least version 17.06
+3. Follow instructions for your OS below to do the build and obtain the
+   firmware file.
+4. After completing the build, the file p600firmware.syx in the current
+   directory is a SysEx file containing the firmware. Follow the instructions
+   in the user guide to install it in your Prophet 600.
+
+### Mac OS X, Linux, other Unix-ish OS using Bash
+
+Run the following commands in your shell:
+```
+cd p600fw/docker
+docker image build -t p600fw-builder .
+id=$(docker container create p600fw-builder)
+docker container start -ai $id
+docker container cp $id:/dist/p600firmware.syx .
+docker container rm $id
+```
+
+### Windows
+
+> Hopefully someone who knows both Bash and the Windows shell can
+> translate the Bash instructions above and will submit a pull request 
+> to add the right instructions here.  :-)

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,7 @@ How-To
 ------
 
 1. Clone this repo to your local system.
-2. First, install Docker CE; at least version 17.06
+2. Install Docker CE; at least version 17.06
 3. Follow instructions for your OS below to do the build and obtain the
    firmware file.
 4. After completing the build, the file p600firmware.syx in the current

--- a/docker/p600fw-build.sh
+++ b/docker/p600fw-build.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+BRANCH=master
+REPO_URL=https://github.com/gligli/p600fw.git
+DIR=p600fw
+
+DIST=/dist
+FILES="p600firmware.bin p600firmware.hex p600firmware.syx"
+
+set -e
+set -x
+git clone $REPO_URL $DIR
+cd $DIR
+if [ "$BRANCH" != "master" ]; then
+  git checkout $BRANCH
+fi
+
+cd firmware
+make
+
+mkdir $DIST
+for f in $FILES; do
+  cp $f /dist/$f
+done


### PR DESCRIPTION
Using Docker, one can reliably and predictably build the P600FW project without needing to install any prerequisites or dependencies other than Docker itself. This pull request includes the necessary Docker configuration and a README describing how to use it. 

I'm not a Windows user so I don't know how to correctly translate the few lines of shell code described in the README to the Windows equivalent. Perhaps someone else will do so?